### PR TITLE
cm: sepolicy: Allow use of dexclassloader by systemserver

### DIFF
--- a/sepolicy/system.te
+++ b/sepolicy/system.te
@@ -12,3 +12,6 @@ allow system_server theme_data_file:dir create_dir_perms;
 allow system_server theme_data_file:file create_file_perms;
 allow system_server resourcecache_data_file:dir create_dir_perms;
 allow system_server resourcecache_data_file:file create_file_perms;
+
+# System server dynamically loads some dexfiles
+allow system_server dex2oat_exec:file execute;


### PR DESCRIPTION
- Needed for custom keyhandler.

Change-Id: Ifa57ad81951f9e1009eb291726cd8dfe36a3482e
